### PR TITLE
Url configurations for project and dataset slugs (3)

### DIFF
--- a/message_coding/apps/dataset/urls.py
+++ b/message_coding/apps/dataset/urls.py
@@ -4,12 +4,14 @@ from django.conf.urls import url, patterns
 
 import views
 
-urlpatterns = patterns('apps.dataset.views',
+urlpatterns = patterns('',
 
-                    # All project-related-urls should start with the project code: ^(?P<project_pk>\d+)/
-                       url(r'^(?P<pk>\d+)/$',
+                       url(r'^import/$',
+                           views.DatasetImportView.as_view(),
+                           name='dataset_import'),
+
+                       url(r'^(?P<dataset_slug>[\w-]+)/$',
                            views.DatasetDetailView.as_view(),
                            name='dataset'),
 
-                       
 )

--- a/message_coding/apps/project/urls.py
+++ b/message_coding/apps/project/urls.py
@@ -1,33 +1,40 @@
 """urlconf for the projects application"""
 
-from django.conf.urls import url, patterns
+from django.conf.urls import url, patterns, include
 
 import views
 
+task_urls = patterns('',
+
+                     url(r'^create/$',
+                         views.CreateTaskView.as_view(),
+                         name='task_create'),
+
+                     url(r'^(?P<task_pk>\d+)/$',
+                         views.TaskDetailView.as_view(),
+                         name='task'),
+)
+
+project_slug_urls = patterns('',
+
+                             url(r'^tasks/',
+                                 include(task_urls)),
+
+                             url(r'^datasets/',
+                                 include('apps.dataset.urls')),
+
+                             url(r'^$',
+                                 views.ProjectDetailView.as_view(),
+                                 name='project'),
+)
+
 urlpatterns = patterns('apps.project.views',
 
-                    # All project-related-urls should start with the project code: ^(?P<project_pk>\d+)/
-                       url(r'^(?P<pk>\d+)/$',
-                          views.ProjectDetailView.as_view(),
-                          name='project'),
+                       url(r'^project/create/$',
+                           views.CreateProjectView.as_view(),
+                           name='project_create'),
 
-                      url(r'^create/$', 
-                          views.CreateProjectView.as_view(),
-                          name='project_create'),
-                       
-                      url(r'^(?P<project_pk>\d+)/task/(?P<pk>\d+)/$',
-                          views.TaskDetailView.as_view(),
-                          name='project_task'),
+                       url(r'^(?P<project_slug>[\w-]+)/', include(project_slug_urls)),
 
-                      url(r'^(?P<project_pk>\d+)/task/create/$',
-                          views.CreateTaskView.as_view(),
-                          name='project_task_create'),
 
-                      url(r'^(?P<project_pk>\d+)/dataset/import/$', 
-                          views.DatasetImport.as_view(),
-                          name='dataset_import'),
-
-                      url(r'^(?P<project_pk>\d+)/datasets/(?P<dataset_pk>\d+)/$', 
-                          views.DatasetDetails.as_view(),
-                          name='dataset_details'),
 )

--- a/message_coding/base/urls.py
+++ b/message_coding/base/urls.py
@@ -1,14 +1,14 @@
 """urlconf for the base application"""
 
-from django.conf.urls import url, patterns
-from django.contrib.auth.views import login
+from django.conf.urls import url, patterns, include
 
 
 urlpatterns = patterns('base.views',
-    url(r'^$', 'home', name='home'),
+                       url(r'^$', 'home', name='home'),
 )
 
-urlpatterns += patterns('', 
-	url(r'^login/$', 'django.contrib.auth.views.login'),
-	url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
+urlpatterns += patterns('',
+                        url(r'^accounts/', include('django.contrib.auth.urls')),
+                        # url(r'^login/$', 'django.contrib.auth.views.login'),
+                        # url(r'^logout/$', 'django.contrib.auth.views.logout', {'next_page': '/'}),
 )

--- a/message_coding/message_coding/urls.py
+++ b/message_coding/message_coding/urls.py
@@ -7,18 +7,19 @@ from django.contrib import admin
 
 
 urlpatterns = patterns('',
-                       url(r'', include('base.urls')),
 
                        # Examples:
                        # url(r'^$', 'messageCoding.views.home', name='home'),
                        # url(r'^blog/', include('blog.urls')),
-                       url(r'^user_dash/','apps.project.views.index'),
-
-                       url(r'^project/', include('apps.project.urls')),
-                       url(r'^dataset/', include('apps.dataset.urls')),
+                       url(r'^user_dash/', 'apps.project.views.index'),
 
                        # Load the admin urls
                        url(r'^admin/', include(admin.site.urls)),
+
+                       url(r'^', include('base.urls')),
+
+                       # Project urls
+                       url(r'^', include('apps.project.urls')),
 )
 
 if settings.DEBUG:


### PR DESCRIPTION
I've refactored the project's url configurations to work with the urls we discussed. This is part 3 for #24, building on #32.

To see how this works, start with the root project urlconf and trace out the imports:

Main urlconf gets loaded first (message_coding/message_coding/urls.py)...
1. Defines `user_dash` url (this is removed in #23)
2. Imports admin url conf
3. Imports urls from "base" app (message_coding/base/urls.py)
4. Imports urls from "project" app (message_coding/apps/project/urls.py)
   1. Defines `project_create` url
   2. Loads the `project_slug_urls` from the same file.
      1. Load the `task_urls` from the same file.
         1. Defines `task_create` url
         2. Defines `task` detail url
      2. Imports the dataset urlconf from the "dataset" app (message_coding/apps/dataset/urls.py)
         1. Defines `dataset_import` url
         2. Defines `dataset` detail url
      3. Define the `project` detail url
