### PR TITLE
Start adding REST api

### DIFF
--- a/message_coding/apps/coding/api.py
+++ b/message_coding/apps/coding/api.py
@@ -1,0 +1,53 @@
+from apps.coding import models
+from rest_framework import routers, serializers, viewsets
+from base import api_utils
+
+
+class CodeSerializer(api_utils.ExclusiveHyperlinkedModelSerializer):
+    class Meta:
+        model = models.Code
+        fields = ('id', 'name', 'description', 'code_group')
+
+
+class CodeGroupSerializer(api_utils.ExclusiveHyperlinkedModelSerializer):
+    class Meta:
+        model = models.CodeGroup
+        fields = ('id', 'name', 'description', 'codes', 'scheme')
+
+    codes = CodeSerializer(many=True, exclude=('code_group',))
+
+
+# Serializers define the API representation.
+class SchemeSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = models.Scheme
+        fields = ('id', 'name', 'description',
+                  'created_at', 'owner', 'project', 'code_groups')
+
+    code_groups = CodeGroupSerializer(many=True, exclude=('scheme',))
+
+
+# ViewSets define the view behavior.
+class SchemeViewSet(viewsets.ModelViewSet):
+    queryset = models.Scheme.objects.all()
+    serializer_class = SchemeSerializer
+    paginate_by = 50
+
+
+class CodeGroupViewSet(viewsets.ModelViewSet):
+    queryset = models.CodeGroup.objects.all()
+    serializer_class = CodeGroupSerializer
+    paginate_by = 50
+
+
+class CodeViewSet(viewsets.ModelViewSet):
+    queryset = models.Code.objects.all()
+    serializer_class = CodeSerializer
+    paginate_by = 50
+
+
+# Routers provide an easy way of automatically determining the URL conf.
+router = routers.SimpleRouter()
+router.register(r'schemes', SchemeViewSet)
+router.register(r'code_groups', CodeGroupViewSet)
+router.register(r'codes', CodeViewSet)

--- a/message_coding/apps/dataset/api.py
+++ b/message_coding/apps/dataset/api.py
@@ -1,0 +1,47 @@
+from apps.dataset.models import Dataset, Selection, Message
+from rest_framework import routers, serializers, viewsets
+
+
+# Serializers define the API representation.
+class DatasetSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Dataset
+        fields = ('id', 'name', 'description', 'slug', 'created_at',
+                  'owner', 'projects')
+
+
+class SelectionSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Selection
+        fields = ('id', 'created_at', 'owner', 'dataset', 'type', 'selection', 'size')
+
+
+class MessageSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Message
+        fields = ('id', 'sender', 'time', 'text', 'dataset')
+
+
+# ViewSets define the view behavior.
+class DatasetViewSet(viewsets.ModelViewSet):
+    queryset = Dataset.objects.all()
+    serializer_class = DatasetSerializer
+    paginate_by = 10
+
+
+class SelectionViewSet(viewsets.ModelViewSet):
+    queryset = Selection.objects.all()
+    serializer_class = SelectionSerializer
+    paginate_by = 10
+
+
+class MessageViewSet(viewsets.ModelViewSet):
+    queryset = Message.objects.all()
+    serializer_class = MessageSerializer
+    paginate_by = 100
+
+# Routers provide an easy way of automatically determining the URL conf.
+router = routers.SimpleRouter()
+router.register(r'datasets', DatasetViewSet)
+router.register(r'selections', SelectionViewSet)
+router.register(r'messages', MessageViewSet)

--- a/message_coding/apps/dataset/models.py
+++ b/message_coding/apps/dataset/models.py
@@ -2,7 +2,6 @@ from django.db import models
 from django.conf import settings
 
 from base.models import NameDescriptionMixin, CreatedAtField
-from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
 
 # These strings cannot be dataset slugs
@@ -42,6 +41,10 @@ class Selection(models.Model):
             return self.dataset.messages.filter(pk__in=ids)
         else:
             return self.dataset.messages.all()
+
+    def size(self):
+        return self.get_messages().count()
+
 
 class Message(models.Model):
     """A single message in a dataset"""

--- a/message_coding/apps/project/api.py
+++ b/message_coding/apps/project/api.py
@@ -1,0 +1,38 @@
+from rest_framework import serializers, viewsets, routers
+
+from apps.project.models import Project, Task
+
+
+# Serializers define the API representation.
+class TaskSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Task
+        fields = ('id', 'name', 'description',
+                  'created_at', 'owner', 'project', 'scheme', 'assigned_coders')
+
+
+class ProjectSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Project
+        fields = ('id', 'name', 'description',
+                  'slug', 'created_at', 'owner', 'members',
+                  'tasks', 'schemes', 'datasets')
+
+
+# ViewSets define the view behavior.
+class ProjectViewSet(viewsets.ModelViewSet):
+    queryset = Project.objects.all()
+    serializer_class = ProjectSerializer
+    paginate_by = 10
+
+
+class TaskViewSet(viewsets.ModelViewSet):
+    queryset = Task.objects.all()
+    serializer_class = TaskSerializer
+    paginate_by = 10
+
+
+# Routers provide an easy way of automatically determining the URL conf.
+router = routers.SimpleRouter()
+router.register(r'projects', ProjectViewSet)
+router.register(r'tasks', TaskViewSet)

--- a/message_coding/apps/project/models.py
+++ b/message_coding/apps/project/models.py
@@ -1,9 +1,10 @@
 from django.db import models
 from django.conf import settings
-
-from base.models import NameDescriptionMixin, CreatedAtField
 from django.core.urlresolvers import reverse
 from django.core.exceptions import ValidationError
+
+from base.models import NameDescriptionMixin, CreatedAtField
+
 
 # These strings cannot be project slugs
 illegal_project_slugs = (
@@ -11,6 +12,7 @@ illegal_project_slugs = (
     'project',
     'accounts',
     'user_dash',
+    'api',
 )
 
 
@@ -22,7 +24,7 @@ def slug_validator(value):
 class Project(NameDescriptionMixin):
     slug = models.SlugField(unique=True, validators=[slug_validator])
     created_at = CreatedAtField()
-    owner = models.ForeignKey(settings.AUTH_USER_MODEL)
+    owner = models.ForeignKey(settings.AUTH_USER_MODEL, related_name='projects_owned')
 
     # People who belong to this project
     members = models.ManyToManyField(settings.AUTH_USER_MODEL, related_name='projects')

--- a/message_coding/base/api.py
+++ b/message_coding/base/api.py
@@ -1,0 +1,33 @@
+from django.contrib.auth import get_user_model
+from rest_framework import routers, serializers, viewsets, permissions
+from base import api_utils
+
+from apps.project import api as project_api
+from apps.dataset import api as dataset_api
+from apps.coding import api as coding_api
+
+
+User = get_user_model()
+
+
+# Serializers define the API representation.
+class UserSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = User
+        fields = ('url', 'username', 'email', 'is_staff', 'projects',
+                  'projects_owned', 'tasks_owned', 'tasks_assigned')
+
+
+# ViewSets define the view behavior.
+class UserViewSet(viewsets.ModelViewSet):
+    queryset = User.objects.all()
+    serializer_class = UserSerializer
+
+
+router = api_utils.SuperRouter()
+router.register('users', UserViewSet)
+router.extend(project_api.router)
+router.extend(dataset_api.router)
+router.extend(coding_api.router)
+
+urlpatterns = router.urls

--- a/message_coding/base/api_utils.py
+++ b/message_coding/base/api_utils.py
@@ -1,0 +1,62 @@
+from rest_framework import routers, serializers, permissions
+
+class SuperRouterMixin(object):
+
+    def extend(self, router):
+        for prefix, viewset, base_name in router.registry:
+            self.registry.append((prefix, viewset, base_name))
+
+class SuperRouter(SuperRouterMixin, routers.DefaultRouter):
+    pass
+
+class SuperSimpleRouter(SuperRouterMixin, routers.SimpleRouter):
+    pass
+
+
+# http://stackoverflow.com/questions/24852555/how-to-exclude-parent-when-serializer-is-nested-when-using-django-rest-framework
+class ExclusiveHyperlinkedModelSerializer(serializers.HyperlinkedModelSerializer):
+    """
+    A HyperlinkedModelSerializer that takes an additional `fields` argument that
+    controls which fields should be displayed.
+    """
+
+    def __init__(self, *args, **kwargs):
+        # Don't pass the 'fields' arg up to the superclass
+        fields = kwargs.pop('fields', None)
+        exclude = kwargs.pop('exclude', None)
+        # Instantiate the superclass normally
+        super(ExclusiveHyperlinkedModelSerializer, self).__init__(*args, **kwargs)
+
+        if fields:
+            # Drop any fields that are not specified in the `fields` argument.
+            allowed = set(fields)
+            existing = set(self.fields.keys())
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
+        if exclude:
+            # Drop fields that are specified in the `exclude` argument.
+            excluded = set(exclude)
+            for field_name in excluded:
+                try:
+                    self.fields.pop(field_name)
+                except KeyError:
+                    pass
+
+
+class IsStaffOrOwner(permissions.BasePermission):
+    """
+    Object-level permission to only allow owners of an object to edit it.
+    Assumes the model instance has an `owner` attribute.
+    """
+    def has_permission(self, request, view):
+        return True
+
+    def has_object_permission(self, request, view, obj):
+        # Instance must have an attribute named `owner`.
+
+        # User may be staff
+        if request.user.is_staff:
+            return True
+
+        return obj.owner == request.user
+

--- a/message_coding/base/urls.py
+++ b/message_coding/base/urls.py
@@ -5,7 +5,14 @@ from django.conf.urls import url, patterns, include
 from base import views
 
 urlpatterns = patterns('',
-    url(r'^$', views.home, name='home'),
-    url(r'^home/$', views.UserDashboard.as_view(), name='user_dash'),
-    url(r'^accounts/', include('django.contrib.auth.urls')),
+                       url(r'^$', views.home, name='home'),
+                       url(r'^home/$', views.UserDashboard.as_view(), name='user_dash'),
+                       url(r'^accounts/', include('django.contrib.auth.urls')),
+
+                       # REST Api urls
+                       url(r'^api/', include('base.api')),
+
+                       # Project urls
+                       url(r'^', include('apps.project.urls')),
+
 )

--- a/message_coding/message_coding/settings/base.py
+++ b/message_coding/message_coding/settings/base.py
@@ -359,3 +359,18 @@ INSTALLED_APPS += (
 # BROKER_VHOST = 'django'
 # CELERY_RESULT_BACKEND = 'amqp'
 ########## END SOUTH CONFIGURATION
+
+
+######### REST FRAMEWORK
+INSTALLED_APPS += (
+    'rest_framework',
+)
+
+REST_FRAMEWORK = {
+    # Use Django's standard `django.contrib.auth` permissions.
+    'DEFAULT_PERMISSION_CLASSES': [
+        'rest_framework.permissions.DjangoModelPermissions'
+    ]
+}
+######### END REST FRAMEWORK
+

--- a/message_coding/message_coding/urls.py
+++ b/message_coding/message_coding/urls.py
@@ -6,6 +6,8 @@ from django.views.generic import TemplateView
 from django.contrib import admin
 
 
+# NOTE: new url segments at the top level
+# should be added to the blacklist for project.Project model slugs.
 urlpatterns = patterns('',
 
                        # Load the admin urls
@@ -13,8 +15,6 @@ urlpatterns = patterns('',
 
                        url(r'^', include('base.urls')),
 
-                       # Project urls
-                       url(r'^', include('apps.project.urls')),
 )
 
 if settings.DEBUG:

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -36,3 +36,8 @@ path.py
 dj-database-url
 django-extensions
 django-widget-tweaks
+
+# rest api
+djangorestframework
+markdown
+django-filter


### PR DESCRIPTION
I started added a REST-style API (#59) using [django-rest-framework](http://www.django-rest-framework.org/) (aka DRF). This creates a web-browsable API endpoint at `/api/` and you can explore this in your browser.

This should already provide create/list/retrieve/update/delete functionality for the basic data types, using urls like `/projects/{id}`. It doesn't do nested queries, like `/projects/{id}/members` but this can be done, though it gets ugly.

We need to do more work to lock down access to data to only the users that actually need access to them, but that's true of the main web UI as well.